### PR TITLE
Remove Collaborator Requirement from Zappr

### DIFF
--- a/.zappr.yaml
+++ b/.zappr.yaml
@@ -21,4 +21,4 @@ approvals:
 #   uncomment these lines to change it to only collaborators
 #   (you can also specify `orgs` and `users` and define `groups`)
 #   from:
-   collaborators: true
+#   collaborators: true


### PR DESCRIPTION
Removed Collaborator Requirement from Zappr
